### PR TITLE
Update libs and modify send to allow batch messages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-kafka",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-kafka",
-  "version": "0.0.12",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -171,8 +171,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
@@ -479,6 +478,22 @@
       "dev": true,
       "requires": {
         "default-require-extensions": "1.0.0"
+      }
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "optional": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "optional": true,
+      "requires": {
+        "delegates": "1.0.0",
+        "readable-stream": "2.3.6"
       }
     },
     "argparse": {
@@ -934,9 +949,9 @@
       }
     },
     "bindings": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
-      "integrity": "sha512-DpLh5EzMR2kzvX1KIlVC0VkC3iZtHKTgdtZ0a3pglBZdaQFjt5S9g9xd1lE+YvXyfd6mtCeRnrUfOLYiTMlNSw==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.1.tgz",
+      "integrity": "sha512-i47mqjF9UbjxJhxGf+pZ6kSxrnI3wBLlnGI2ArWJ4r0VrvDS7ZYXkprq/pLaBWYq4GM0r4zdHY+NNRqEMU7uew==",
       "optional": true
     },
     "bl": {
@@ -1009,10 +1024,32 @@
         "node-int64": "0.4.0"
       }
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "optional": true,
+      "requires": {
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "optional": true
+    },
     "buffer-crc32": {
       "version": "0.2.13",
       "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
       "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "optional": true
     },
     "buffer-from": {
       "version": "1.0.0",
@@ -1164,6 +1201,17 @@
       "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
+    "chownr": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "optional": true
+    },
     "ci-info": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.3.tgz",
@@ -1260,8 +1308,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "dev": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -1343,6 +1390,11 @@
         "typedarray": "0.0.6"
       }
     },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+    },
     "contains-path": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
@@ -1393,6 +1445,11 @@
         "shebang-command": "1.2.0",
         "which": "1.3.0"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
     },
     "cryptiles": {
       "version": "3.1.2",
@@ -1565,6 +1622,21 @@
       "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
       "dev": true
     },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "optional": true,
+      "requires": {
+        "mimic-response": "1.0.1"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true
+    },
     "deep-is": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
@@ -1675,6 +1747,17 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true
+    },
+    "denque": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-1.4.0.tgz",
+      "integrity": "sha512-gh513ac7aiKrAgjiIBWZG0EASyDF9p4JMWwKA8YU5s9figrL5SRNEMT6FDynsegakuhWd1wVqTvqvqAoDxw7wQ=="
+    },
     "detect-indent": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
@@ -1683,6 +1766,12 @@
       "requires": {
         "repeating": "2.0.1"
       }
+    },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -1763,6 +1852,14 @@
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
+      }
+    },
+    "end-of-stream": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "requires": {
+        "once": "1.4.0"
       }
     },
     "errno": {
@@ -2187,6 +2284,12 @@
         "fill-range": "2.2.4"
       }
     },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "optional": true
+    },
     "expect": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/expect/-/expect-21.2.1.tgz",
@@ -2425,6 +2528,12 @@
         "map-cache": "0.2.2"
       }
     },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "optional": true
+    },
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2438,7 +2547,7 @@
       "dev": true,
       "optional": true,
       "requires": {
-        "nan": "2.10.0",
+        "nan": "2.11.1",
         "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
@@ -2972,6 +3081,22 @@
       "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
       "dev": true
     },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "optional": true,
+      "requires": {
+        "aproba": "1.2.0",
+        "console-control-strings": "1.1.0",
+        "has-unicode": "2.0.1",
+        "object-assign": "4.1.1",
+        "signal-exit": "3.0.2",
+        "string-width": "1.0.2",
+        "strip-ansi": "3.0.1",
+        "wide-align": "1.1.3"
+      }
+    },
     "generate-function": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
@@ -3013,6 +3138,12 @@
       "requires": {
         "assert-plus": "1.0.0"
       }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "optional": true
     },
     "glob": {
       "version": "7.1.2",
@@ -3646,6 +3777,12 @@
         "sparkles": "1.0.0"
       }
     },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true
+    },
     "has-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
@@ -3826,6 +3963,12 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
       "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
+    "ini": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+      "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+      "optional": true
+    },
     "inquirer": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
@@ -3914,8 +4057,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
-      "dev": true
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-builtin-module": {
       "version": "1.0.0",
@@ -4015,7 +4157,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -5368,7 +5509,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -5401,9 +5543,9 @@
       }
     },
     "kafka-node": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/kafka-node/-/kafka-node-2.6.1.tgz",
-      "integrity": "sha512-tpivkSLjiGHRLwx0YN87fMUATOK4NYWESJneHlpikEBNNA5od7fW/ikovS3tWooMqG4Nri55vPFRUNiNvNBWZA==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/kafka-node/-/kafka-node-3.0.1.tgz",
+      "integrity": "sha512-id9bdOQ35OkrQHHbIjtpC02Y2kTpmLQw/B9wbe6uAzjkLaRyu30GnJoz22vZ8uBB9DZ0JgwjHrKOK7sB3i41LA==",
       "requires": {
         "async": "2.6.0",
         "binary": "0.3.0",
@@ -5411,13 +5553,14 @@
         "buffer-crc32": "0.2.13",
         "buffermaker": "1.2.0",
         "debug": "2.6.9",
+        "denque": "1.4.0",
         "lodash": "4.17.10",
         "minimatch": "3.0.4",
-        "nested-error-stacks": "2.0.0",
+        "nested-error-stacks": "2.1.0",
         "node-zookeeper-client": "0.2.2",
         "optional": "0.1.4",
         "retry": "0.10.1",
-        "snappy": "6.0.4",
+        "snappy": "6.1.1",
         "uuid": "3.2.1"
       }
     },
@@ -5669,11 +5812,6 @@
         "yallist": "2.1.2"
       }
     },
-    "lsmod": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/lsmod/-/lsmod-1.0.0.tgz",
-      "integrity": "sha1-mgD3bco26yP6BTUK/htYXUKZ5ks="
-    },
     "makeerror": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/makeerror/-/makeerror-1.0.11.tgz",
@@ -5703,6 +5841,16 @@
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
       "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
+    },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.6"
+      }
     },
     "mem": {
       "version": "1.1.0",
@@ -5770,6 +5918,12 @@
       "integrity": "sha1-ggyGo5M0ZA6ZUWkovQP8qIBX0CI=",
       "dev": true
     },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "optional": true
+    },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -5781,8 +5935,7 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mixin-deep": {
       "version": "1.3.1",
@@ -5809,7 +5962,6 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -5835,9 +5987,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.1.tgz",
+      "integrity": "sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==",
       "optional": true
     },
     "nanomatch": {
@@ -5880,6 +6032,12 @@
         }
       }
     },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
+      "optional": true
+    },
     "natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -5887,18 +6045,32 @@
       "dev": true
     },
     "nested-error-stacks": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.0.0.tgz",
-      "integrity": "sha1-mLL/rvtGEPo5NvHnFDXTBwDeKEA=",
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/nested-error-stacks/-/nested-error-stacks-2.1.0.tgz",
+      "integrity": "sha512-AO81vsIO1k1sM4Zrd6Hu7regmJN1NSiAja10gc4bX3F0wd+9rQmcuHQaHVQCYIEC8iFXnE+mavh23GOt7wBgug=="
     },
     "next-tick": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.0.0.tgz",
       "integrity": "sha1-yobR/ogoFpsBICCOPchCS524NCw=",
       "dev": true
+    },
+    "node-abi": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.5.0.tgz",
+      "integrity": "sha512-9g2twBGSP6wIR5PW7tXvAWnEWKJDH/VskdXp168xsw9VVxpEGov8K4jsP4/VeoC7b2ZAyzckvMCuQuQlw44lXg==",
+      "optional": true,
+      "requires": {
+        "semver": "5.6.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "5.6.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+          "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+          "optional": true
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -5942,6 +6114,12 @@
         }
       }
     },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "optional": true
+    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
@@ -5972,11 +6150,22 @@
         "path-key": "2.0.1"
       }
     },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "1.1.5",
+        "console-control-strings": "1.1.0",
+        "gauge": "2.7.4",
+        "set-blocking": "2.0.0"
+      }
+    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "dev": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "nwmatcher": {
       "version": "1.4.4",
@@ -5993,8 +6182,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
     },
     "object-copy": {
       "version": "0.1.0",
@@ -6082,7 +6270,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -6136,8 +6323,7 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "dev": true
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
     },
     "os-locale": {
       "version": "2.1.0",
@@ -6341,6 +6527,38 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
+    "prebuild-install": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.2.tgz",
+      "integrity": "sha512-4e8VJnP3zJdZv/uP0eNWmr2r9urp4NECw7Mt1OSAi3rcLrbBRxGiAkfUFtre2MhQ5wfREAjRV+K1gubvs/GPsA==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "1.0.3",
+        "expand-template": "2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "1.2.0",
+        "mkdirp": "0.5.1",
+        "napi-build-utils": "1.0.1",
+        "node-abi": "2.5.0",
+        "noop-logger": "0.1.1",
+        "npmlog": "4.1.2",
+        "os-homedir": "1.0.2",
+        "pump": "2.0.1",
+        "rc": "1.2.8",
+        "simple-get": "2.8.1",
+        "tar-fs": "1.16.3",
+        "tunnel-agent": "0.6.0",
+        "which-pm-runs": "1.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "optional": true
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6418,6 +6636,16 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "optional": true,
+      "requires": {
+        "end-of-stream": "1.4.1",
+        "once": "1.4.0"
+      }
+    },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
@@ -6431,10 +6659,10 @@
       "dev": true
     },
     "quintoandar-logger": {
-      "version": "git+https://github.com/quintoandar/node-logger.git#c21f7fa094f9e46ef2374a37d1bf831dce612d03",
+      "version": "git+https://github.com/quintoandar/node-logger.git#11ec29995bd703a351d18cfe8d905f1f757e6f5c",
       "requires": {
-        "winston": "2.4.2",
-        "winston-sentry": "0.2.1"
+        "winston": "2.4.4",
+        "winston-raven-sentry": "1.0.1"
       }
     },
     "randomatic": {
@@ -6462,27 +6690,23 @@
         }
       }
     },
-    "raven": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/raven/-/raven-1.2.1.tgz",
-      "integrity": "sha1-lJwTTbAooZC3u/j3kKrlQbfAIL0=",
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
       "requires": {
-        "cookie": "0.3.1",
-        "json-stringify-safe": "5.0.1",
-        "lsmod": "1.0.0",
-        "stack-trace": "0.0.9",
-        "uuid": "3.0.0"
+        "deep-extend": "0.6.0",
+        "ini": "1.3.5",
+        "minimist": "1.2.0",
+        "strip-json-comments": "2.0.1"
       },
       "dependencies": {
-        "stack-trace": {
-          "version": "0.0.9",
-          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
-          "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
-        },
-        "uuid": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.0.tgz",
-          "integrity": "sha1-Zyj8BFnEUNeWqZwxg3VpvfZy1yg="
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "optional": true
         }
       }
     },
@@ -7137,8 +7361,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-      "dev": true
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
     "set-value": {
       "version": "2.0.0",
@@ -7193,8 +7416,24 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
-      "dev": true
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+    },
+    "simple-concat": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
+      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+      "optional": true
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "optional": true,
+      "requires": {
+        "decompress-response": "3.3.0",
+        "once": "1.4.0",
+        "simple-concat": "1.0.0"
+      }
     },
     "slash": {
       "version": "1.0.0",
@@ -7328,13 +7567,14 @@
       }
     },
     "snappy": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.0.4.tgz",
-      "integrity": "sha512-+MjETxi/G7fLtiLFWW9n9VLzpJvOVqRRohJ7kTgaU4bUJ37rsoWwxhZzO91BOB7sCgOILtKsGtCUviUo3REIfQ==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/snappy/-/snappy-6.1.1.tgz",
+      "integrity": "sha512-QTv+NJUVWfDMq1edGhmIgn/8TI3Pc+G2sxHOoV8NU0gDMeHaYgnyhIq/U6W+mv6wGmbdhq+bRyXggIoDUSjQng==",
       "optional": true,
       "requires": {
-        "bindings": "1.3.0",
-        "nan": "2.10.0"
+        "bindings": "1.3.1",
+        "nan": "2.11.1",
+        "prebuild-install": "5.2.2"
       }
     },
     "sntp": {
@@ -7524,7 +7764,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -7549,7 +7788,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -7569,8 +7807,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
     },
     "supports-color": {
       "version": "2.0.0",
@@ -7629,6 +7866,45 @@
             "ansi-regex": "3.0.0"
           }
         }
+      }
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "optional": true,
+      "requires": {
+        "chownr": "1.1.1",
+        "mkdirp": "0.5.1",
+        "pump": "1.0.3",
+        "tar-stream": "1.6.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "optional": true,
+          "requires": {
+            "end-of-stream": "1.4.1",
+            "once": "1.4.0"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "optional": true,
+      "requires": {
+        "bl": "1.2.2",
+        "buffer-alloc": "1.2.0",
+        "end-of-stream": "1.4.1",
+        "fs-constants": "1.0.0",
+        "readable-stream": "2.3.6",
+        "to-buffer": "1.1.1",
+        "xtend": "4.0.1"
       }
     },
     "test-exclude": {
@@ -8008,6 +8284,11 @@
       "integrity": "sha1-dkpaEa9QVhkhsTPztE5hhofg9cM=",
       "dev": true
     },
+    "timed-out": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-4.0.1.tgz",
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+    },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
@@ -8022,6 +8303,12 @@
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.4.tgz",
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "optional": true
     },
     "to-fast-properties": {
       "version": "1.0.3",
@@ -8196,7 +8483,6 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -8545,6 +8831,21 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "optional": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "optional": true,
+      "requires": {
+        "string-width": "1.0.2"
+      }
+    },
     "window-size": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
@@ -8552,9 +8853,9 @@
       "dev": true
     },
     "winston": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
-      "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
+      "version": "2.4.4",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.4.tgz",
+      "integrity": "sha512-NBo2Pepn4hK4V01UfcWcDlmiVTs7VTB1h7bgnB0rgP146bYhMxX0ypCz3lBOfNxCO4Zuek7yeT+y/zM1OfMw4Q==",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",
@@ -8566,18 +8867,37 @@
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
           "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
     },
-    "winston-sentry": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/winston-sentry/-/winston-sentry-0.2.1.tgz",
-      "integrity": "sha1-39zIKPNac1qOAeeBkYr2UuuXx1w=",
+    "winston-raven-sentry": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/winston-raven-sentry/-/winston-raven-sentry-1.0.1.tgz",
+      "integrity": "sha512-TAaAJlFMpCKXUNDjCu/I1tBlDsVUxvRzPFlYu3PeaiJg/aXVnp1+W4HHqxJTzTIR5lrG8PqsfBIw5ojG8H71Zg==",
       "requires": {
         "lodash": "4.17.10",
-        "raven": "1.2.1"
+        "raven": "2.6.4"
+      },
+      "dependencies": {
+        "raven": {
+          "version": "2.6.4",
+          "resolved": "https://registry.npmjs.org/raven/-/raven-2.6.4.tgz",
+          "integrity": "sha512-6PQdfC4+DQSFncowthLf+B6Hr0JpPsFBgTVYTAOq7tCmx/kR4SXbeawtPch20+3QfUcQDoJBLjWW1ybvZ4kXTw==",
+          "requires": {
+            "cookie": "0.3.1",
+            "md5": "2.2.1",
+            "stack-trace": "0.0.10",
+            "timed-out": "4.0.1",
+            "uuid": "3.3.2"
+          }
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+        }
       }
     },
     "wordwrap": {
@@ -8608,8 +8928,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",
@@ -8650,8 +8969,7 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
-      "dev": true
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "y18n": {
       "version": "3.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-kafka",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Default Kafka NodeJS lib for QuintoAndar",
   "main": "src/main.js",
   "types": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "main": "src/main.js",
   "types": "types/index.d.ts",
   "dependencies": {
-    "kafka-node": "2.6.1",
+    "kafka-node": "^3.0.1",
     "lodash": "^4.17.10",
-    "quintoandar-logger": "git+https://github.com/quintoandar/node-logger.git#1.0.0",
+    "quintoandar-logger": "git+https://github.com/quintoandar/node-logger.git#2.0.0",
     "uuid": "^3.2.1"
   },
   "devDependencies": {

--- a/src/node-kafka-producer.js
+++ b/src/node-kafka-producer.js
@@ -43,7 +43,25 @@ class KafkaProducer {
           if (err) {
             reject(err);
           } else {
-            data.message = msg;
+            resolve(data);
+          }
+        });
+      });
+    });
+    return sendPromisse;
+  }
+
+  sendBatch(topic, msg) {
+    if (!Array.isArray(msg)) {
+      throw new Error('For sendBatch the second parameter should be an array of messages');
+    }
+    const sendPromisse = new Promise((resolve, reject) => {
+      const payload = { topic, messages: msg };
+      this.readyPromisse.then(() => {
+        this.producer.send([payload], (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
             resolve(data);
           }
         });

--- a/src/node-kafka-producer.js
+++ b/src/node-kafka-producer.js
@@ -37,26 +37,12 @@ class KafkaProducer {
 
   send(topic, msg) {
     const sendPromisse = new Promise((resolve, reject) => {
-      const payload = { topic, messages: [msg] };
-      this.readyPromisse.then(() => {
-        this.producer.send([payload], (err, data) => {
-          if (err) {
-            reject(err);
-          } else {
-            resolve(data);
-          }
-        });
-      });
-    });
-    return sendPromisse;
-  }
-
-  sendBatch(topic, msg) {
-    if (!Array.isArray(msg)) {
-      throw new Error('For sendBatch the second parameter should be an array of messages');
-    }
-    const sendPromisse = new Promise((resolve, reject) => {
-      const payload = { topic, messages: msg };
+      let payload;
+      if (Array.isArray(msg)) {
+        payload = { topic, messages: msg };
+      } else {
+        payload = { topic, messages: [msg] };
+      }
       this.readyPromisse.then(() => {
         this.producer.send([payload], (err, data) => {
           if (err) {

--- a/tests/node-kafka-producer.test.js
+++ b/tests/node-kafka-producer.test.js
@@ -2,7 +2,6 @@ jest.mock('node-rdkafka');
 jest.mock('uuid');
 const KafkaProducer = require('../src/node-kafka-producer').KafkaProducer;
 
-const msg = 'test';
 const topic = 'TestTopic';
 
 describe('Kafka Prducer Configs Validation', () => {
@@ -30,41 +29,87 @@ describe('Kafka Producer', () => {
     done();
   });
 
-  it('should produce when ready', (done) => {
-    const producer = new KafkaProducer({ configs });
-    producer.send(topic, msg).then(() => {
-      expect(producer.producer.send.mock.calls[0][0]).toEqual([{
-        topic,
-        messages: [msg],
-        message: msg
-      }]);
-      done();
+  describe('send', () => {
+    const msg = 'test';
+
+    it('should produce when ready', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.send(topic, msg).then(() => {
+        expect(producer.producer.send.mock.calls[0][0]).toEqual([{
+          topic,
+          messages: [msg],
+        }]);
+        done();
+      });
+      producer.producer.emit('ready');
     });
-    producer.producer.emit('ready');
+    it('should produce when ready', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.producer.emit('ready');
+      producer.send(topic, msg).then(() => {
+        expect(producer.producer.send.mock.calls[0][0]).toEqual([{
+          topic,
+          messages: [msg],
+        }]);
+        done();
+      });
+    });
+    it('should reject promise on error', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.producer.emit('ready');
+      producer.producer.send = jest.fn().mockImplementation((payload, cb) => {
+        cb(new Error('some error'));
+      });
+      producer.send(topic, msg).catch((err) => {
+        expect(err).toEqual(new Error('some error'));
+        done();
+      });
+    });
   });
 
-  it('should produce when ready', (done) => {
-    const producer = new KafkaProducer({ configs });
-    producer.producer.emit('ready');
-    producer.send(topic, msg).then(() => {
-      expect(producer.producer.send.mock.calls[0][0]).toEqual([{
-        topic,
-        messages: [msg],
-        message: msg
-      }]);
-      done();
-    });
-  });
+  describe('sendBatch', () => {
+    const batchMsgs = ['test1', 'test2'];
 
-  it('should reject promise on error', (done) => {
-    const producer = new KafkaProducer({ configs });
-    producer.producer.emit('ready');
-    producer.producer.send = jest.fn().mockImplementation((payload, cb) => {
-      cb(new Error('some error'));
-    });
-    producer.send(topic, msg).catch((err) => {
-      expect(err).toEqual(new Error('some error'));
+    it('sendBatch should throw error if not using array', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.producer.emit('ready');
+      expect(() => {
+        producer.sendBatch(topic, 'a string');
+      }).toThrow(Error);
       done();
+    });
+    it('sendBatch should produce when ready', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.sendBatch(topic, batchMsgs).then(() => {
+        expect(producer.producer.send.mock.calls[0][0]).toEqual([{
+          topic,
+          messages: batchMsgs,
+        }]);
+        done();
+      });
+      producer.producer.emit('ready');
+    });
+    it('sendBatch should produce when ready', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.producer.emit('ready');
+      producer.sendBatch(topic, batchMsgs).then(() => {
+        expect(producer.producer.send.mock.calls[0][0]).toEqual([{
+          topic,
+          messages: batchMsgs,
+        }]);
+        done();
+      });
+    });
+    it('should reject promise on error', (done) => {
+      const producer = new KafkaProducer({ configs });
+      producer.producer.emit('ready');
+      producer.producer.send = jest.fn().mockImplementation((payload, cb) => {
+        cb(new Error('some error'));
+      });
+      producer.sendBatch(topic, batchMsgs).catch((err) => {
+        expect(err).toEqual(new Error('some error'));
+        done();
+      });
     });
   });
 });

--- a/tests/node-kafka-producer.test.js
+++ b/tests/node-kafka-producer.test.js
@@ -31,6 +31,7 @@ describe('Kafka Producer', () => {
 
   describe('send', () => {
     const msg = 'test';
+    const batchMsgs = ['test1', 'test2'];
 
     it('should produce when ready', (done) => {
       const producer = new KafkaProducer({ configs });
@@ -65,22 +66,9 @@ describe('Kafka Producer', () => {
         done();
       });
     });
-  });
-
-  describe('sendBatch', () => {
-    const batchMsgs = ['test1', 'test2'];
-
-    it('sendBatch should throw error if not using array', (done) => {
+    it('with array of messages, should produce when ready', (done) => {
       const producer = new KafkaProducer({ configs });
-      producer.producer.emit('ready');
-      expect(() => {
-        producer.sendBatch(topic, 'a string');
-      }).toThrow(Error);
-      done();
-    });
-    it('sendBatch should produce when ready', (done) => {
-      const producer = new KafkaProducer({ configs });
-      producer.sendBatch(topic, batchMsgs).then(() => {
+      producer.send(topic, batchMsgs).then(() => {
         expect(producer.producer.send.mock.calls[0][0]).toEqual([{
           topic,
           messages: batchMsgs,
@@ -89,10 +77,10 @@ describe('Kafka Producer', () => {
       });
       producer.producer.emit('ready');
     });
-    it('sendBatch should produce when ready', (done) => {
+    it('with array of messages, should produce when ready', (done) => {
       const producer = new KafkaProducer({ configs });
       producer.producer.emit('ready');
-      producer.sendBatch(topic, batchMsgs).then(() => {
+      producer.send(topic, batchMsgs).then(() => {
         expect(producer.producer.send.mock.calls[0][0]).toEqual([{
           topic,
           messages: batchMsgs,
@@ -100,13 +88,13 @@ describe('Kafka Producer', () => {
         done();
       });
     });
-    it('should reject promise on error', (done) => {
+    it('with array of messages, should reject promise on error', (done) => {
       const producer = new KafkaProducer({ configs });
       producer.producer.emit('ready');
       producer.producer.send = jest.fn().mockImplementation((payload, cb) => {
         cb(new Error('some error'));
       });
-      producer.sendBatch(topic, batchMsgs).catch((err) => {
+      producer.send(topic, batchMsgs).catch((err) => {
         expect(err).toEqual(new Error('some error'));
         done();
       });


### PR DESCRIPTION
* Previous send would work only for a single message (because it eventually does `messages: [msg]`).
* But `kafka-node` also has better performance if we send it in batch (and also warns that [we might miss messages if we don't batch messages from the same topic](https://github.com/SOHU-Co/kafka-node#producer)), so I have created a `sendBatch` that accepts an array of messages.
* Also, updates kafka-node and logging lib.