### PR TITLE
add handleMessageFn error handling

### DIFF
--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -26,7 +26,7 @@ class KafkaConsumer {
       throw new Error(`Missing Consumer Configs ${missingConfigs}`);
     }
     if (typeof this.handleMessageFn !== 'function') {
-      throw new Error('HandleMessageFn must be a fucntion');
+      throw new Error('HandleMessageFn must be a function');
     }
     if (this.topics && this.topics.constructor !== Array) {
       throw new Error('Topics must be an array');
@@ -43,8 +43,12 @@ class KafkaConsumer {
     this.consumer.on('data', (msg) => {
       this.handleMessageFn(msg).then(() => {
         this.consumer.commit(msg, true);
+      }).catch((err) => {
+        logger.error(`Consumer error on handleMessageFn: ${err}.
+          The following message was not committed: ${msg}`);
       });
     });
+
     setInterval(this.refreshMetadata.bind(this), this.configs.updateMetadata);
     logger.info('ConsumerGroupStream started');
   }


### PR DESCRIPTION
#### WHAT
When an error occurs in `handleMessageFn`, the kafka consumer group enters in a dead state.

#### WHY
Currently, the subscribed kafka consumers are "afraid" of letting errors reach the `ConsumerGroupStream`. They never let it propagate over `quintoandar-kafka`, catching the errors themselves and sending a false positive to the `ConsumerGroupStream`, which commits them.

#### HOW
As a result of this PR, we want to allow the consumers to propagate errors to the consumer group stream without breaking it, stop false-positives and log those errors. Then we should be able to remove those try/catch from the consumers (i.e. Charizard, us-emails...).

ref: https://github.com/quintoandar/us-emails/pull/327