### PR TITLE
Fix msg in error logger in handleMessageFn

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Standard node consumer/producer implementation for QuintoAndar.
 
 ## Examples
 
-See [exemples folder](/example)
+See [examples folder](/example)
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-kafka",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Default Kafka NodeJS lib for QuintoAndar",
   "main": "src/main.js",
   "types": "types/index.d.ts",

--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -36,7 +36,7 @@ class KafkaConsumer {
   init() {
     this.consumer = new kafka.ConsumerGroupStream(this.configs, this.topics);
     this.consumer.on('error', (err) => {
-      logger.error('node-kafka error: ', err);
+      logger.error('node-kafka error:', err);
       process.exit(1);
     });
 
@@ -45,8 +45,8 @@ class KafkaConsumer {
         this.consumer.commit(msg, true);
       }).catch((err) => {
         logger.error(
-          'Consumer error on handleMessageFn: ', err,
-          'The following message was not committed: ', msg
+          'The following message was not committed:', msg,
+          'Consumer error on handleMessageFn:', err
         );
       });
     });
@@ -60,7 +60,7 @@ class KafkaConsumer {
       this.consumer.consumerGroup.topics,
       (err) => {
         if (err) {
-          logger.warn('Refresh metadata error: ', err);
+          logger.warn('Refresh metadata error:', err);
           if (err.name === 'BrokerNotAvailableError') {
             this.consumer.close(() => {
               process.exit(1);

--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -44,8 +44,10 @@ class KafkaConsumer {
       this.handleMessageFn(msg).then(() => {
         this.consumer.commit(msg, true);
       }).catch((err) => {
-        logger.error(`Consumer error on handleMessageFn: ${err}.
-          The following message was not committed: ${msg}`);
+        logger.error(
+          'Consumer error on handleMessageFn: ', err,
+          'The following message was not committed: ', msg
+        );
       });
     });
 


### PR DESCRIPTION
`quintoandar-logger` deals better with comma separation, in comparison to string concatenation (or template literals, like in this case). It was logging [object Object] in some cases.