### PR TITLE
[SPC-106] Do not kill the process on every consumer error

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "quintoandar-kafka",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2568,12 +2568,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2588,17 +2590,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2715,7 +2720,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2727,6 +2733,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2741,6 +2748,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2748,12 +2756,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2772,6 +2782,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2852,7 +2863,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2864,6 +2876,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2985,6 +2998,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",

--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -51,6 +51,10 @@ class KafkaConsumer {
     logger.info('ConsumerGroupStream started');
   }
 
+  onError(handler) {
+    this.consumer.on('error', handler);
+  }
+
   refreshMetadata() {
     this.consumer.consumerGroup.client.refreshMetadata(
       this.consumer.consumerGroup.topics,

--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -37,7 +37,6 @@ class KafkaConsumer {
     this.consumer = new kafka.ConsumerGroupStream(this.configs, this.topics);
     this.consumer.on('error', (err) => {
       logger.error('node-kafka error:', err);
-      process.exit(1);
     });
 
     this.consumer.on('data', (msg) => {

--- a/tests/node-kafka-consumer.test.js
+++ b/tests/node-kafka-consumer.test.js
@@ -104,11 +104,12 @@ describe('Kafka Consumer', () => {
 
   it('should throw error on error event', (done) => {
     const handleMessageFn = handleMessageMock(done);
+    const handleErrorFn = jest.fn();
     const consumer = new KafkaConsumer({ configs, topics, handleMessageFn });
-    global.process.exit = jest.fn();
     consumer.init();
+    consumer.onError(handleErrorFn);
     consumer.consumer.emit('error', 'error');
-    expect(global.process.exit).toHaveBeenCalledWith(1);
+    expect(handleErrorFn).toHaveBeenCalledWith('error');
     done();
   });
 });


### PR DESCRIPTION
# Problem

We observed that in some situations, especially when there is a lot of messages to process, the consumer starts dying with a high frequency.

The reason for that is because for every error happening on the consumer, the application gets killed by the handler. This would not be a problem if these errors put the application in an inconsistent or irreparable state, but that is not the case. Most of the errors were simple timeouts given by some network instability or by the broker not being able to respond to the request in a reasonable time.

This behavior results in the following problems:
- downtime of the application that needs to be restarted
- a lot of messages being reprocessed because the consumer dies before committing it

# Fix

Removed the line that kills the application on every consumer error.

# Possible side effects

If a consumer request results in some kind of error the application will not get killed immediately. This could be a problem if the consumer is not capable of recovering itself, it would stop consuming messages but would still be running forever.

This scenario is already being handled by the `refreshMetadata` function, that checks on every `updateMetadata` time interval the broker connection and if it's not successful it kills the process.

If there is some kind of error that keeps the application connected to the broker but keeps the client unable to process messages, then this specific error should also kill the process. As for now, we do not know if this type of error exists.