### PR TITLE
Trying to avoid leak on event listeners

### DIFF
--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -34,7 +34,7 @@ class KafkaConsumer {
   }
 
   init() {
-    if (typeof (this.consumer) === 'undefined') {
+    if (typeof (this.consumer) !== 'undefined') {
       logger.info('Kafka consumer had already been initialized. Skipping.');
       return;
     }

--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -34,6 +34,11 @@ class KafkaConsumer {
   }
 
   init() {
+    if(typeof(this.consumer) === 'undefined') {
+      logger.info('Kafka consumer had already been initialized. Skipping.');
+      return;
+    }
+
     this.consumer = new kafka.ConsumerGroupStream(this.configs, this.topics);
     this.consumer.on('error', (err) => {
       logger.error('node-kafka error:', err);

--- a/src/node-kafka-consumer.js
+++ b/src/node-kafka-consumer.js
@@ -34,7 +34,7 @@ class KafkaConsumer {
   }
 
   init() {
-    if(typeof(this.consumer) === 'undefined') {
+    if (typeof (this.consumer) === 'undefined') {
       logger.info('Kafka consumer had already been initialized. Skipping.');
       return;
     }

--- a/src/node-kafka-producer.js
+++ b/src/node-kafka-producer.js
@@ -20,6 +20,11 @@ class KafkaProducer {
   }
 
   init() {
+    if(typeof(this.client) === 'undefined') {
+      logger.info('Kafka producer had already been initialized. Skipping.');
+      return;
+    }
+
     this.client = new kafka.KafkaClient(this.configs);
     this.producer = new kafka.HighLevelProducer(this.client);
     this.producer.on('error', logger.error);

--- a/src/node-kafka-producer.js
+++ b/src/node-kafka-producer.js
@@ -20,7 +20,7 @@ class KafkaProducer {
   }
 
   init() {
-    if (typeof (this.client) === 'undefined') {
+    if (typeof (this.client) !== 'undefined') {
       logger.info('Kafka producer had already been initialized. Skipping.');
       return;
     }

--- a/src/node-kafka-producer.js
+++ b/src/node-kafka-producer.js
@@ -20,7 +20,7 @@ class KafkaProducer {
   }
 
   init() {
-    if(typeof(this.client) === 'undefined') {
+    if (typeof (this.client) === 'undefined') {
       logger.info('Kafka producer had already been initialized. Skipping.');
       return;
     }


### PR DESCRIPTION
init method allow to be called multiple times, creating multiple connections and multiple listeners.
Trying to reduce it
Identified by: https://sentry.io/organizations/quintoandar-r5/issues/1507690146/?environment=worker-forno&environment=api-forno&project=1837997&project=2217255&query=is%3Aunresolved